### PR TITLE
recurses

### DIFF
--- a/gourts/gourt.gd
+++ b/gourts/gourt.gd
@@ -126,11 +126,6 @@ func try_enter_door():
 	result[0].collider.interract(self)
 	print(result[0].collider.name)
 
-func try_enter_door_recursive_downwards():
-	if foot_friend:
-		foot_friend.try_enter_door_recursive_downwards()
-	try_enter_door()
-
 #var special_layer = ProjectSettings.get_setting("layer_names/2d_physics/special solid") todo
 const special_layer = 4
 func is_special_collision(k: KinematicCollision2D) -> bool:
@@ -197,7 +192,6 @@ func _physics_process(delta: float) -> void:
 	if is_on_floor():
 		apply_friction(Vector2(walk_friction,0))
 
-
 	if walk_target != 0 || is_on_floor(): #this check prevents unwanted drag on airborne guorts
 		velocity.x = move_toward(velocity.x, walk_target, walk_accel)
 
@@ -224,8 +218,4 @@ func _process(delta: float) -> void:
 
 func _input(ev: InputEvent) -> void:
 	if ev.is_action_pressed("enter door"):
-		var stack_tip = Gourtilities.get_stack_tip(self)
-		if stack_tip != self:
-			stack_tip._input(ev)
-			return
-		try_enter_door_recursive_downwards()
+		Gourtilities.call_all(self, func(g): g.try_enter_door())

--- a/gourts/gourtilities.gd
+++ b/gourts/gourtilities.gd
@@ -23,6 +23,7 @@ func stack_now(g: Gourt, onto: Gourt):
 		resolve_perch(former_head_friend)
 
 # --- Recursive helpers ---
+# call
 func call_all_downwards(g: Gourt, f: Callable):
 	f.call(g)
 	if g.foot_friend:
@@ -39,6 +40,23 @@ func call_all(g: Gourt, f: Callable):
 		call_all_downwards(g.foot_friend, f)
 	if g.head_friend:
 		call_all_upwards(g.head_friend, f)
+
+# list
+func list_head_friends(g: Gourt, acc: Array[Gourt] = []) -> Array[Gourt]:
+	if g.head_friend:
+		acc.append(g.head_friend)
+		return list_head_friends(g.head_friend, acc)
+	return acc
+
+func list_foot_friends(g: Gourt, acc: Array[Gourt] = []) -> Array[Gourt]:
+	if g.foot_friend:
+		acc.append(g.foot_friend)
+		return list_foot_friends(g.foot_friend, acc)
+	return acc
+
+func list_stack_members(g: Gourt):
+## note that the returned list is in no particular order
+	return list_foot_friends(g) + [g] + list_head_friends(g)
 
 # --- Recursive functions ---
 

--- a/gourts/gourtilities.gd
+++ b/gourts/gourtilities.gd
@@ -22,11 +22,31 @@ func stack_now(g: Gourt, onto: Gourt):
 	if former_head_friend:
 		resolve_perch(former_head_friend)
 
-func resolve_perch(g: Gourt):
+# --- Recursive helpers ---
+func call_all_downwards(g: Gourt, f: Callable):
+	f.call(g)
 	if g.foot_friend:
-		g.position = perch_position(g.foot_friend)
+		call_all_downwards(g.foot_friend, f)
+
+func call_all_upwards(g: Gourt, f: Callable):
+	f.call(g)
 	if g.head_friend:
-		resolve_perch(g.head_friend)
+		call_all_upwards(g.head_friend, f)
+
+func call_all(g: Gourt, f: Callable):
+	f.call(g)
+	if g.foot_friend:
+		call_all_downwards(g.foot_friend, f)
+	if g.head_friend:
+		call_all_upwards(g.head_friend, f)
+
+# --- Recursive functions ---
+
+func resolve_perch(g: Gourt):
+	call_all_upwards(g, func(g: Gourt):
+		if g.foot_friend:
+			g.position = perch_position(g.foot_friend)
+	)
 
 func head_count(g: Gourt):
 	if g.head_friend:

--- a/gourts/gourtilities.gd
+++ b/gourts/gourtilities.gd
@@ -67,19 +67,13 @@ func resolve_perch(g: Gourt):
 	)
 
 func head_count(g: Gourt):
-	if g.head_friend:
-		return 1 + head_count(g.head_friend)
-	return 0
+	return list_head_friends(g).size()
 
 func foot_count(g: Gourt):
-	if g.foot_friend:
-		return 1 + foot_count(g.foot_friend)
-	return 0
+	return list_foot_friends(g).size()
 
 func stack_count(g: Gourt):
 	return head_count(g) + foot_count(g) + 1
 
 func get_stack_tip(g: Gourt):
-	if g.head_friend:
-		return get_stack_tip(g.head_friend)
-	return g
+	return list_head_friends(g)[-1] if g.head_friend else g

--- a/level/office-level.tscn
+++ b/level/office-level.tscn
@@ -158,7 +158,6 @@ head_friend = NodePath("../Gourt5")
 foot_friend = NodePath("../Gourt0")
 
 [node name="Master" type="Camera2D" parent="." node_paths=PackedStringArray("player_character")]
-position_smoothing_enabled = true
 script = ExtResource("14_b2cyw")
 player_character = NodePath("../Gourt Stack/Gourt1")
 metadata/_custom_type_script = "uid://cdsy208jbfkdj"

--- a/level/office-level.tscn
+++ b/level/office-level.tscn
@@ -158,6 +158,7 @@ head_friend = NodePath("../Gourt5")
 foot_friend = NodePath("../Gourt0")
 
 [node name="Master" type="Camera2D" parent="." node_paths=PackedStringArray("player_character")]
+position_smoothing_enabled = true
 script = ExtResource("14_b2cyw")
 player_character = NodePath("../Gourt Stack/Gourt1")
 metadata/_custom_type_script = "uid://cdsy208jbfkdj"


### PR DESCRIPTION
- add recursive helpers in Gourtilities noly to discover there are actuallly quite a lot of different types of recursion to take into account
- add list functions to Gourtilities, which can be used for map and reduce
- rewrite Gourtilities to use recursive helpers wherever possible.
- undo accidentally added change
- simplify enter door logic using a recursion helper

This solves one of the four issues with the Door PR; the complicated enter door logic
