### PR TITLE
camera zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,6 @@ twitch integtation
 # See Also (auto-generated)
 [office-level/todo.md](./level/office-level/todo.md)
 
-[` class_name Master #TODO  this class should be more generic  player and AI should inheret from it`](./player.gd)
-
-[` #TODO how does input priority work exactly? Does it make this reording unneccesary?`](./player.gd)
-
-[` ) #TODO  this is not 100% correct, you can still see substantuially more with a bigger screen`](./player.gd)
-
-[` var items = Clision.get_objects_at(event_position(ev), "interactive") #TODO sort this list for more consisten results`](./player.gd)
-
-[` player_character._interact(interactables[0], ev_pos) #TODO we should try to handle the whole array not just whatever is arbitrarily the first element`](./player.gd)
-
-[` return initial.move_toward(direction * sharpness / delta, snappiness) - initial #TODO refactor`](./tools/yute.gd)
-
-[` var text_size = text_line.get_size() * 1.02 #FIXME calculation is slightly undersized.`](./ui/speech_bubble/speech_bubble.gd)
-
-[` r.position = global_position #TODO getting our own global rect reliably is more steps than this`](./ui/speech_bubble/speech_bubble.gd)
-
 [` extends CharacterBody2D #TODO  I HATE OOP I HATE OOP (inheritence need to be reworked if we want more than just CharacterBody2D to be controllable)`](./actor.gd)
 
 [` var bounds_size = 60 #TODO this is the gourt's size, and it's a guess`](./actor.gd)
@@ -45,11 +29,21 @@ twitch integtation
 
 [` $Sprite2D.rotation = 0 #FIXME Gourts don't have Sprite2D, really need to unify sprite logic somewhere`](./actor.gd)
 
+[` return initial.move_toward(direction * sharpness / delta, snappiness) - initial #TODO refactor`](./tools/yute.gd)
+
+[` var text_size = text_line.get_size() * 1.02 #FIXME calculation is slightly undersized.`](./ui/speech_bubble/speech_bubble.gd)
+
+[` r.position = global_position #TODO getting our own global rect reliably is more steps than this`](./ui/speech_bubble/speech_bubble.gd)
+
+[` back.z_index = Gourtilities.get_stack_base(wearer).z_index -plus_z #BM2`](./gourts/disguise/disguise.gd)
+
+[` z_index = wearer.z_index + plus_z #TODO calculate the wearer's global z_index`](./gourts/disguise/disguise.gd)
+
+[` func stack(g  Gourt, onto  Gourt)  #BM1`](./gourts/gourtilities.gd)
+
 [` extends Actor #TODO  I HATE OOP I HATE OOP (inheritence need to be reworked if we want more than just CharacterBody2D to be controllable)`](./gourts/gourt.gd)
 
 [` @export var stack_elasticity = 0.5 #FIXME  setting this above 0.5 results in infinte-energy.`](./gourts/gourt.gd)
-
-[` #TODO reimplement to be less guesswork-oriented `](./gourts/gourt.gd)
 
 [` foot_friend.head_friend = null #BM1`](./gourts/gourt.gd)
 
@@ -59,13 +53,15 @@ twitch integtation
 
 [` func can_reach(o) -> bool  #TODO more reliable test would check if we can reach any part, not just the center`](./gourts/gourt.gd)
 
-[` back.z_index = Gourtilities.get_stack_base(wearer).z_index -plus_z #BM2`](./gourts/disguise/disguise.gd)
-
-[` z_index = wearer.z_index + plus_z #TODO calculate the wearer's global z_index`](./gourts/disguise/disguise.gd)
-
-[` func stack(g  Gourt, onto  Gourt)  #BM1`](./gourts/gourtilities.gd)
-
 [` target_slot = operator.get_node("Body/HandSlot1") #TODO think about left/right hands/legs`](./props/equipable.gd)
 
 [` var open_state = false #TODO work will be needed to allow door to start open`](./props/elevator/elevator.gd)
+
+[` class_name Master #TODO  this class should be more generic  player and AI should inheret from it`](./player.gd)
+
+[` #TODO how does input priority work exactly? Does it make this reording unneccesary?`](./player.gd)
+
+[` var items = Clision.get_objects_at(event_position(ev), "interactive") #TODO sort this list for more consisten results`](./player.gd)
+
+[` player_character._interact(interactables[0], ev_pos) #TODO we should try to handle the whole array not just whatever is arbitrarily the first element`](./player.gd)
 

--- a/actors/conversation.gd
+++ b/actors/conversation.gd
@@ -1,6 +1,7 @@
 extends Area2D
 
 @export var actors: Array[Actor]
+@export var autostart = false
 
 class Line:
 	var text: String
@@ -47,6 +48,26 @@ func display_line():
 		await line.call()
 		display_line()
 
+func _process(delta):
+	queue_redraw()
+
+func _draw():
+	var r = Yute.get_global_rect(self)
+	r.position -= position
+	draw_rect(r, Color("blue", 0.5))
+
+var started = false
+func start():
+	if started:
+		return
+	started = true
+	display_line.call_deferred()
+
+func on_activation_zone_entered(area: Area2D):
+	start()
 
 func _ready():
-	display_line.call_deferred()
+	if autostart:
+		start()
+	else:
+		area_entered.connect(on_activation_zone_entered)

--- a/actors/conversation.gd
+++ b/actors/conversation.gd
@@ -48,14 +48,6 @@ func display_line():
 		await line.call()
 		display_line()
 
-func _process(delta):
-	queue_redraw()
-
-func _draw():
-	var r = Yute.get_global_rect(self)
-	r.position -= position
-	draw_rect(r, Color("blue", 0.5))
-
 var started = false
 func start():
 	if started:

--- a/actors/conversation.tscn
+++ b/actors/conversation.tscn
@@ -2,11 +2,13 @@
 
 [ext_resource type="Script" uid="uid://cnvx1nc2i330f" path="res://actors/conversation.gd" id="1_h5wgq"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_twwvs"]
-size = Vector2(825, 730)
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_c3vaa"]
+resource_local_to_scene = true
 
 [node name="Conversation" type="Area2D"]
+collision_layer = 8
+collision_mask = 128
 script = ExtResource("1_h5wgq")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("RectangleShape2D_twwvs")
+shape = SubResource("RectangleShape2D_c3vaa")

--- a/gourts/gourt.gd
+++ b/gourts/gourt.gd
@@ -30,15 +30,6 @@ func break_stack(impulse_scale: int = 1) -> void:
 		Yute.triangular_distribution(-1, -2)
 	) * impulse_scale, "breaksplosion")
 
-#TODO reimplement to be less guesswork-oriented 
-func get_global_rect() -> Rect2:
-	if head_friend:
-		return head_friend.get_global_rect()
-	else:
-		var self_bounds = super()
-		self_bounds.size.y *= Gourtilities.foot_count(self)
-		return self_bounds
-
 func abdicate(nominee: Actor = null) -> bool:
 	if not master:
 		return false #idk whether it should be true or false, we'll have to see

--- a/level/activation_zone.gd
+++ b/level/activation_zone.gd
@@ -1,0 +1,7 @@
+extends Area2D
+
+@onready var parent: Camera2D = get_parent()
+@onready var initial_size: Vector2 = $CollisionShape2D.shape.size
+
+func _physics_process(delta: float) -> void:
+	$CollisionShape2D.shape.size = initial_size / parent.zoom

--- a/level/activation_zone.gd
+++ b/level/activation_zone.gd
@@ -4,4 +4,5 @@ extends Area2D
 @onready var initial_size: Vector2 = $CollisionShape2D.shape.size
 
 func _physics_process(delta: float) -> void:
-	$CollisionShape2D.shape.size = initial_size / parent.zoom
+	pass
+	#$CollisionShape2D.shape.size = initial_size / parent.zoom

--- a/level/activation_zone.gd
+++ b/level/activation_zone.gd
@@ -3,6 +3,13 @@ extends Area2D
 @onready var parent: Camera2D = get_parent()
 @onready var initial_size: Vector2 = $CollisionShape2D.shape.size
 
-func _physics_process(delta: float) -> void:
-	pass
-	#$CollisionShape2D.shape.size = initial_size / parent.zoom
+
+func reset_encompass():
+	$CollisionShape2D.position = Vector2.ZERO
+	$CollisionShape2D.shape.size = initial_size
+
+func encompass(r: Rect2):
+	reset_encompass()
+	var new_rect = Yute.union_rect([Yute.get_global_rect(self), r])
+	$CollisionShape2D.global_position = new_rect.get_center()
+	$CollisionShape2D.shape.size = new_rect.size

--- a/level/activation_zone.gd.uid
+++ b/level/activation_zone.gd.uid
@@ -1,0 +1,1 @@
+uid://6foq1gufj00l

--- a/level/level-container.gd
+++ b/level/level-container.gd
@@ -39,4 +39,5 @@ func load_scene_after_curtains(scn: PackedScene) -> Node:
 	return load_scene(scn)
 
 func reset_level():
-	load_scene_after_curtains(current_level_scene)
+	await load_scene_after_curtains(current_level_scene)
+	cleanup()

--- a/level/level-container.tscn
+++ b/level/level-container.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cy3lpj00ijf0" path="res://level/level-container.gd" id="1_2bolc"]
 [ext_resource type="PackedScene" uid="uid://b57lobk2dccaj" path="res://level/office-level.tscn" id="2_8r3cm"]
 [ext_resource type="Shader" uid="uid://mqwxsmjr1l7f" path="res://ui/curtains/curtain.gdshader" id="2_ukkco"]
-[ext_resource type="Script" path="res://ui/curtains/curtain.gd" id="3_8r3cm"]
+[ext_resource type="Script" uid="uid://d4nybgrjevcxy" path="res://ui/curtains/curtain.gd" id="3_8r3cm"]
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_44x8d"]
 noise_type = 0

--- a/level/office-level.tscn
+++ b/level/office-level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://b57lobk2dccaj"]
+[gd_scene load_steps=34 format=4 uid="uid://b57lobk2dccaj"]
 
 [ext_resource type="Texture2D" uid="uid://clphjaysvxh82" path="res://level/office-level/tiles.png" id="1_wxgj7"]
 [ext_resource type="PackedScene" uid="uid://c6a0ra2cd2h4g" path="res://props/sunglasses.tscn" id="3_rh3h7"]
@@ -73,6 +73,10 @@ resource_local_to_scene = true
 shader = ExtResource("14_1axx8")
 shader_parameter/grow = 0.0
 shader_parameter/handle = Vector2(0, 0)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5ybge"]
+resource_local_to_scene = true
+size = Vector2(1620, 654)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_4gsd2"]
 resource_local_to_scene = true
@@ -163,7 +167,7 @@ player_character = NodePath("../Gourt Stack/Gourt1")
 metadata/_custom_type_script = "uid://cdsy208jbfkdj"
 
 [node name="ActivationZone" type="Area2D" parent="Master"]
-collision_layer = 0
+collision_layer = 128
 collision_mask = 8
 script = ExtResource("12_5y8te")
 
@@ -185,13 +189,15 @@ facing = 3
 
 [node name="Conversation" parent="." node_paths=PackedStringArray("actors") instance=ExtResource("15_1axx8")]
 position = Vector2(1960, -29)
-collision_layer = 8
-collision_mask = 0
 actors = [NodePath("../Inspectors"), NodePath("../Janitor"), NodePath("../Gourt Stack/Gourt0")]
+
+[node name="CollisionShape2D" parent="Conversation" index="0"]
+position = Vector2(61, 31)
+shape = SubResource("RectangleShape2D_5ybge")
 
 [node name="Gourt Stack" parent="." node_paths=PackedStringArray("root_child") instance=ExtResource("12_utg4x")]
 y_sort_enabled = true
-position = Vector2(908, 239)
+position = Vector2(-978, 402)
 root_child = NodePath("Gourt0")
 
 [node name="Gourt0" parent="Gourt Stack" node_paths=PackedStringArray("head_friend") instance=ExtResource("13_ax68m")]
@@ -328,4 +334,5 @@ head_friend = NodePath("../Gourt14")
 foot_friend = NodePath("../Gourt0")
 
 [editable path="TileMapLayer/Door"]
+[editable path="Conversation"]
 [editable path="Gourt Stack"]

--- a/level/office-level.tscn
+++ b/level/office-level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=4 uid="uid://b57lobk2dccaj"]
+[gd_scene load_steps=33 format=4 uid="uid://b57lobk2dccaj"]
 
 [ext_resource type="Texture2D" uid="uid://clphjaysvxh82" path="res://level/office-level/tiles.png" id="1_wxgj7"]
 [ext_resource type="PackedScene" uid="uid://c6a0ra2cd2h4g" path="res://props/sunglasses.tscn" id="3_rh3h7"]
@@ -9,6 +9,7 @@
 [ext_resource type="Texture2D" uid="uid://bbimgxq3cdac" path="res://props/stroller.png" id="10_yl1fq"]
 [ext_resource type="Texture2D" uid="uid://c2yk215wr6t2u" path="res://props/table.png" id="11_6o0x5"]
 [ext_resource type="PackedScene" uid="uid://w8bqgkgk58k5" path="res://gourts/disguise/disguise.tscn" id="12_4gsd2"]
+[ext_resource type="Script" uid="uid://6foq1gufj00l" path="res://level/activation_zone.gd" id="12_5y8te"]
 [ext_resource type="PackedScene" uid="uid://cji7qwgt0f3t8" path="res://gourts/stack.tscn" id="12_utg4x"]
 [ext_resource type="Texture2D" uid="uid://bcuiskm22h53j" path="res://props/poster.png" id="13_1slrw"]
 [ext_resource type="PackedScene" uid="uid://bdhee0fbyvgae" path="res://gourts/gourt.tscn" id="13_ax68m"]
@@ -57,6 +58,9 @@ radius = 33.1361
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_w4oyg"]
 radius = 26.0
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5y8te"]
+size = Vector2(1154, 640)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_twwvs"]
 resource_local_to_scene = true
@@ -158,6 +162,14 @@ script = ExtResource("14_b2cyw")
 player_character = NodePath("../Gourt Stack/Gourt1")
 metadata/_custom_type_script = "uid://cdsy208jbfkdj"
 
+[node name="ActivationZone" type="Area2D" parent="Master"]
+collision_layer = 0
+collision_mask = 8
+script = ExtResource("12_5y8te")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Master/ActivationZone"]
+shape = SubResource("RectangleShape2D_5y8te")
+
 [node name="Janitor" parent="." instance=ExtResource("14_twwvs")]
 material = SubResource("ShaderMaterial_twwvs")
 position = Vector2(2203, 49)
@@ -172,12 +184,14 @@ collision_mask = 5
 facing = 3
 
 [node name="Conversation" parent="." node_paths=PackedStringArray("actors") instance=ExtResource("15_1axx8")]
-position = Vector2(1913, -29)
-actors = [NodePath("../Inspectors"), NodePath("../Janitor")]
+position = Vector2(1960, -29)
+collision_layer = 8
+collision_mask = 0
+actors = [NodePath("../Inspectors"), NodePath("../Janitor"), NodePath("../Gourt Stack/Gourt0")]
 
 [node name="Gourt Stack" parent="." node_paths=PackedStringArray("root_child") instance=ExtResource("12_utg4x")]
 y_sort_enabled = true
-position = Vector2(-876, 529)
+position = Vector2(908, 239)
 root_child = NodePath("Gourt0")
 
 [node name="Gourt0" parent="Gourt Stack" node_paths=PackedStringArray("head_friend") instance=ExtResource("13_ax68m")]

--- a/level/office-level/todo.md
+++ b/level/office-level/todo.md
@@ -23,7 +23,7 @@ x:done, -:underway
 -- [x] inter-gourt-action
 - [ ] Level Triggers
 -- [ ] Invisible wall
--- [ ] Camera Focus Zone
+-- [x] Camera Focus Zone
 - [ ] Unstacking
 -- [x] low ceiling
 -- [ ] orphan gourt behaviours
@@ -37,7 +37,7 @@ x:done, -:underway
 -- [x] Movement / action
 - [-] Camera
 -- [x] Focus on player character
--- [ ] Focus in additional objects
+-- [x] Focus in additional objects
 -- [ ] Manual override for cutscenes
 - [ ] Cursor
 - [x] Game Over

--- a/player.gd
+++ b/player.gd
@@ -9,9 +9,9 @@ class_name Master #TODO: this class should be more generic: player and AI should
 			a.under_new_management(self)
 		player_character = a
 
-@export_range(1, 100) var position_smoothing: float = 10
-@export_range(0, 100) var position_threshold: float = 10
-@export_range(1, 1000) var zoom_smoothing: float = 100
+@export_range(0, 1) var position_smoothing: float = 0.1
+@export_range(0, 500) var position_threshold: float = 50
+@export_range(0, 5) var zoom_smoothing: float = 1
 @export_range(1, 10) var max_zoom: float = 1
 
 func valid_actor(a: Actor) -> bool:
@@ -35,6 +35,9 @@ func get_commands(c: Actor.Commands = null) -> Actor.Commands:
 func _process(delta):
 	Engine.time_scale = 0.1 if Input.is_action_pressed("slomo") else 1.0
 
+func smooth(delta: float, smoothing: float):
+	return (delta / smoothing) if smoothing > 0 else 1
+
 func _physics_process(delta: float) -> void:
 	if player_character:
 		player_character.command(get_commands())
@@ -51,9 +54,8 @@ func _physics_process(delta: float) -> void:
 		) #TODO: this is not 100% correct, you can still see substantuially more with a bigger screen
 		# the goal is to completely abstract out screen size so we never have to worry about it again
 
-		# FIXME smoothing factors don't use delta so smoothing is tick/frame rate dependant
-		global_position += position_error.move_toward(Vector2.ZERO, position_threshold) / position_smoothing
-		zoom = lerp(zoom, Vector2.ONE * zoom_error, 1/zoom_smoothing)
+		global_position += position_error.move_toward(Vector2.ZERO, position_threshold) * smooth(delta, position_smoothing)
+		zoom = lerp(zoom, Vector2.ONE * zoom_error, smooth(delta, zoom_smoothing))
 
 func event_position(ev: InputEvent) -> Vector2:
 	if ev is InputEventMouse or ev is InputEventScreenTouch:

--- a/player.gd
+++ b/player.gd
@@ -63,8 +63,15 @@ func smooth(delta: float, smoothing: float):
 
 func _physics_process(delta: float) -> void:
 	if player_character:
-		var track_rects: Array[Rect2] = [Yute.get_global_rect(player_character)]
-		$ActivationZone.global_position = Yute.union_rect(track_rects).get_center()
+		var track_rects: Array[Rect2]
+		if player_character is Gourt:
+			for g in Gourtilities.list_stack_members(player_character):
+				track_rects.append(Yute.get_global_rect(g))
+		else:
+			track_rects = [Yute.get_global_rect(player_character)]
+		var primary_track_rect = Yute.union_rect(track_rects)
+		$ActivationZone.global_position = primary_track_rect.get_center()
+		$ActivationZone.encompass(primary_track_rect)
 
 		for a: Area2D in $ActivationZone.get_overlapping_areas():
 			track_rects.append(Yute.get_global_rect(a))

--- a/player.gd
+++ b/player.gd
@@ -33,7 +33,6 @@ func get_commands(c: Actor.Commands = null) -> Actor.Commands:
 	return c
 
 func _process(delta):
-	queue_redraw()
 	if player_character:
 		player_character.command(get_commands())
 	Engine.time_scale = 0.1 if Input.is_action_pressed("slomo") else 1.0
@@ -155,8 +154,3 @@ func nominate(a: Actor) -> bool:
 		return false
 	player_character = a
 	return player_character == a
-
-func _draw():
-	var r = Yute.get_global_rect($ActivationZone)
-	r.position -= position
-	draw_rect(r, Color("red", 0.5))

--- a/player.gd
+++ b/player.gd
@@ -33,10 +33,9 @@ func get_commands(c: Actor.Commands = null) -> Actor.Commands:
 	return c
 
 func _process(delta):
+	if player_character:
+		player_character.command(get_commands())
 	Engine.time_scale = 0.1 if Input.is_action_pressed("slomo") else 1.0
-
-func smooth(delta: float, smoothing: float):
-	return (delta / smoothing) if smoothing > 0 else 1
 
 class TrackingError:
 	var position_error: Vector2
@@ -58,24 +57,20 @@ func get_tracking_error(track_bounds: Rect2, track_target: Rect2) -> TrackingErr
 		)
 	)
 
-func correct_rect(r: Rect2, error: TrackingError):
-	return Rect2(
-		(r.position - r.get_center()) * error.zoom_error + r.get_center() + error.position_error,
-		r.size / error.zoom_error 
-	)
+func smooth(delta: float, smoothing: float):
+	return (delta / smoothing) if smoothing > 0 else 1
 
-var corrected_rect: Rect2
 func _physics_process(delta: float) -> void:
 	if player_character:
-		player_character.command(get_commands())
-		var viewport_rect = Yute.get_viewport_world_rect(self)
+		var track_rects: Array[Rect2] = [Yute.get_global_rect(player_character)]
+
+		for a: Area2D in $ActivationZone.get_overlapping_areas():
+			track_rects.append(Yute.get_global_rect(a))
+
 		var t_err = get_tracking_error(
-			viewport_rect,
-			player_character.get_global_rect(),
+			Yute.get_viewport_world_rect(self),
+			Yute.union_rect(track_rects),
 		)
-		corrected_rect = correct_rect(viewport_rect, t_err)
-		corrected_rect.position -= position
-		queue_redraw()
 		global_position += t_err.position_error.move_toward(Vector2.ZERO, position_threshold) * smooth(delta, position_smoothing)
 		zoom = lerp(zoom, Vector2.ONE * t_err.zoom_error, smooth(delta, zoom_smoothing))
 
@@ -150,7 +145,3 @@ func nominate(a: Actor) -> bool:
 		return false
 	player_character = a
 	return player_character == a
-
-func _draw():
-	if corrected_rect:
-		draw_rect(corrected_rect, Color("red"), false, 100)

--- a/player.gd
+++ b/player.gd
@@ -38,24 +38,46 @@ func _process(delta):
 func smooth(delta: float, smoothing: float):
 	return (delta / smoothing) if smoothing > 0 else 1
 
+class TrackingError:
+	var position_error: Vector2
+	var zoom_error: float
+	func _init(position_error: Vector2, zoom_error: float):
+		self.position_error = position_error
+		self.zoom_error = zoom_error
+
+func get_tracking_error(track_bounds: Rect2, track_target: Rect2) -> TrackingError:
+	var error_vectors = [
+		track_target.position - track_bounds.position,
+		track_target.end - track_bounds.end
+	]
+	return TrackingError.new(
+		(error_vectors[0] + error_vectors[1]) / 2,
+		min(
+			(error_vectors[0].x - error_vectors[1].x) / track_bounds.size.x,
+			(error_vectors[0].y - error_vectors[1].y) / track_bounds.size.y
+		)
+	)
+
+func correct_rect(r: Rect2, error: TrackingError):
+	return Rect2(
+		(r.position - r.get_center()) * error.zoom_error + r.get_center() + error.position_error,
+		r.size / error.zoom_error 
+	)
+
+var corrected_rect: Rect2
 func _physics_process(delta: float) -> void:
 	if player_character:
 		player_character.command(get_commands())
-		var track_bounds = player_character.get_global_rect()
-		var view_bounds = Yute.get_viewport_world_rect(self)
-		var error_vectors = [
-			track_bounds.position - view_bounds.position,
-			track_bounds.end - view_bounds.end
-		]
-		var position_error = (error_vectors[0] + error_vectors[1]) / 2
-		var zoom_error = min(
-			(error_vectors[0].x - error_vectors[1].x) / view_bounds.size.x,
-			(error_vectors[0].y - error_vectors[1].y) / view_bounds.size.y
-		) #TODO: this is not 100% correct, you can still see substantuially more with a bigger screen
-		# the goal is to completely abstract out screen size so we never have to worry about it again
-
-		global_position += position_error.move_toward(Vector2.ZERO, position_threshold) * smooth(delta, position_smoothing)
-		zoom = lerp(zoom, Vector2.ONE * zoom_error, smooth(delta, zoom_smoothing))
+		var viewport_rect = Yute.get_viewport_world_rect(self)
+		var t_err = get_tracking_error(
+			viewport_rect,
+			player_character.get_global_rect(),
+		)
+		corrected_rect = correct_rect(viewport_rect, t_err)
+		corrected_rect.position -= position
+		queue_redraw()
+		global_position += t_err.position_error.move_toward(Vector2.ZERO, position_threshold) * smooth(delta, position_smoothing)
+		zoom = lerp(zoom, Vector2.ONE * t_err.zoom_error, smooth(delta, zoom_smoothing))
 
 func event_position(ev: InputEvent) -> Vector2:
 	if ev is InputEventMouse or ev is InputEventScreenTouch:
@@ -128,3 +150,7 @@ func nominate(a: Actor) -> bool:
 		return false
 	player_character = a
 	return player_character == a
+
+func _draw():
+	if corrected_rect:
+		draw_rect(corrected_rect, Color("red"), false, 100)

--- a/player.gd
+++ b/player.gd
@@ -33,6 +33,7 @@ func get_commands(c: Actor.Commands = null) -> Actor.Commands:
 	return c
 
 func _process(delta):
+	queue_redraw()
 	if player_character:
 		player_character.command(get_commands())
 	Engine.time_scale = 0.1 if Input.is_action_pressed("slomo") else 1.0
@@ -63,6 +64,7 @@ func smooth(delta: float, smoothing: float):
 func _physics_process(delta: float) -> void:
 	if player_character:
 		var track_rects: Array[Rect2] = [Yute.get_global_rect(player_character)]
+		$ActivationZone.global_position = Yute.union_rect(track_rects).get_center()
 
 		for a: Area2D in $ActivationZone.get_overlapping_areas():
 			track_rects.append(Yute.get_global_rect(a))
@@ -71,6 +73,7 @@ func _physics_process(delta: float) -> void:
 			Yute.get_viewport_world_rect(self),
 			Yute.union_rect(track_rects),
 		)
+		# TODO additional zones should have different smoothing settings than the player:
 		global_position += t_err.position_error.move_toward(Vector2.ZERO, position_threshold) * smooth(delta, position_smoothing)
 		zoom = lerp(zoom, Vector2.ONE * t_err.zoom_error, smooth(delta, zoom_smoothing))
 
@@ -145,3 +148,8 @@ func nominate(a: Actor) -> bool:
 		return false
 	player_character = a
 	return player_character == a
+
+func _draw():
+	var r = Yute.get_global_rect($ActivationZone)
+	r.position -= position
+	draw_rect(r, Color("red", 0.5))

--- a/project.godot
+++ b/project.godot
@@ -90,6 +90,7 @@ interact={
 2d_physics/layer_4="camera zone"
 2d_physics/layer_5="door"
 2d_physics/layer_6="interactive"
+2d_physics/layer_8="camera activator"
 
 [physics]
 

--- a/project.godot
+++ b/project.godot
@@ -87,7 +87,7 @@ interact={
 2d_physics/layer_1="solid"
 2d_physics/layer_2="characters"
 2d_physics/layer_3="special solid"
-2d_physics/layer_4="gaura"
+2d_physics/layer_4="camera zone"
 2d_physics/layer_5="door"
 2d_physics/layer_6="interactive"
 

--- a/tools/yute.gd
+++ b/tools/yute.gd
@@ -61,6 +61,20 @@ func nearest_overlapping_position(inner: Rect2, outer: Rect2) -> Vector2:
 
 	return new_pos
 
+func union_rect(a: Array[Rect2]) -> Rect2:
+	if not a:
+		return Rect2()
+
+	var top_left = a[0].position
+	var bottom_right = a[0].end
+	for r in a:
+		top_left.x = r.position.x if r.position.x < top_left.x else top_left.x
+		top_left.y = r.position.y if r.position.y > top_left.y else top_left.y
+		bottom_right.x = r.end.x if r.end.x > bottom_right.x else bottom_right.x
+		bottom_right.y = r.end.y if r.end.y < bottom_right.y else bottom_right.y
+
+	return Rect2(top_left, bottom_right - top_left)
+
 func get_global_rect(o: Node) -> Rect2:
 	if not o:
 		return Rect2(Vector2.ZERO, Vector2.ZERO)
@@ -71,6 +85,13 @@ func get_global_rect(o: Node) -> Rect2:
 			var r = o.get_rect()
 			r.position += o.global_position
 			return r
+	if o is CollisionShape2D and o.shape:
+		var r = o.shape.get_rect()
+		r.position += o.global_position
+	if o is Area2D:
+		for child in o.get_children():
+			if child is CollisionShape2D and child.shape:
+				return get_global_rect(child)
 
 	return Rect2(o.global_position, Vector2.ZERO)
 

--- a/tools/yute.gd
+++ b/tools/yute.gd
@@ -88,6 +88,7 @@ func get_global_rect(o: Node) -> Rect2:
 	if o is CollisionShape2D and o.shape:
 		var r = o.shape.get_rect()
 		r.position += o.global_position
+		return r
 	if o is Area2D:
 		for child in o.get_children():
 			if child is CollisionShape2D and child.shape:

--- a/tools/yute.gd
+++ b/tools/yute.gd
@@ -69,9 +69,9 @@ func union_rect(a: Array[Rect2]) -> Rect2:
 	var bottom_right = a[0].end
 	for r in a:
 		top_left.x = r.position.x if r.position.x < top_left.x else top_left.x
-		top_left.y = r.position.y if r.position.y > top_left.y else top_left.y
+		top_left.y = r.position.y if r.position.y < top_left.y else top_left.y
 		bottom_right.x = r.end.x if r.end.x > bottom_right.x else bottom_right.x
-		bottom_right.y = r.end.y if r.end.y < bottom_right.y else bottom_right.y
+		bottom_right.y = r.end.y if r.end.y > bottom_right.y else bottom_right.y
 
 	return Rect2(top_left, bottom_right - top_left)
 


### PR DESCRIPTION
Add camera zones which can draw the camera's attention to additional objects. The camera zones can also function as level trigger: the conversation now only starts when you walk close to it. Various related fixes

- improve camera smoothing
- break out error vectors calculation in prep for resusing it, add an ettempt to reverse the error vectors into a useable Rect, which falls short of actually working
- scrap the dynamic primary zone idea because complicated to implement and would probably generate infinte bugs due to tying element of game logic to the screen size. Instead use a fixed aspect ratio area that resizes itself based on zoom and add some nice yutes to Yute to get the new rect calculation working. It does work, but has that predictable problem of getting stuck on the thing that it's focused on
- tweak camera zones settings, add debug drawing and simplify a bunch
- fix game over
- set up layers and colliderts
- something something uuid
- Make camera activation zone encompass the player character. Remove the wonky get_global_rect from gourt.gd that gets the stack rect instead of the individual's rect, which was likely to cause a bit of confusion. Yet to tell if this will cause any bugs but it seems fine so far. Instead have the camera calculate the stack rect itself using the new Yute.union_rect. Fix a big in union_rect causing the calculated rects to be upside-downRemove the wonky get_global_rect from gourt.gd that gets the stack rect instead of the individual's rect, which was likely to cause a bit of confusion. Instead have the camera calculate the stack rect itself using the new Yute.union_rect. Fix a big in union_rect causing the calculated rects to be upside-down.
- remove debug drawing code and update docs
